### PR TITLE
Add `.ok` property to responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "nock"
   ],
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "6.4.5",
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.3.13",

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ export default function(superagent) {
 					status: reply.status,
 					response: reply.result
 				};
-				res.ok=false;
+				res.ok = false;
 			}
 
 			try {

--- a/src/index.js
+++ b/src/index.js
@@ -94,19 +94,21 @@ export default function(superagent) {
 				reply = reply.status(this.url) || {status: 500};
 			}
 
+			// sheldon: the correct superagent behavior is to have res even in error case
+			const res = {
+				status: reply.status,
+				body: reply.result,
+				ok: true
+			};
+
 			let err;
 			if (reply.status >= 400) {
 				err = {
 					status: reply.status,
 					response: reply.result
 				};
+				res.ok=false;
 			}
-
-			// sheldon: the correct superagent behavior is to have res even in error case
-			const res = {
-				status: reply.status,
-				body: reply.result
-			};
 
 			try {
 				cb && cb(err, res);


### PR DESCRIPTION
The response was missing the `.ok` property that's normally on superagent responses.