### PR TITLE
Added injecting response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ nock.get('/events/10')
 ```
 The result to return
 ```js
-nock.reply(httpStatus, responseBody)
+nock.reply(httpStatus, responseBody, responseHeaders)
 ```
 or specify a function
 ```js
 nock.reply(function() {
    return {
       status: 200,
-      result: responseBody
+      result: responseBody,
+      headers: {'access-token': 'example-JSON-Web-Token'}
    };
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -50,14 +50,15 @@ Object.keys(methodsMapping).forEach(method => {
 });
 
 // Reply function
-mock.reply = (status, result) => {
+mock.reply = (status, result, headers) => {
 	if (!currentRoute) {
 		throw new Error('Must call get, post, put, del or patch before reply');
 	}
 
 	currentRoute.reply = {
 		status,
-		result
+		result,
+		headers
 	};
 
 	return mock; // chaining
@@ -98,6 +99,7 @@ export default function(superagent) {
 			const res = {
 				status: reply.status,
 				body: reply.result,
+				headers: reply.headers,
 				ok: true
 			};
 


### PR DESCRIPTION
Right now there is no way of injecting custom response headers, but sometimes this feature is needed to retrieve some data like JWT.